### PR TITLE
fixed logic for processEvent branching + log instead of error call

### DIFF
--- a/vaultaire-collector-ceilometer.cabal
+++ b/vaultaire-collector-ceilometer.cabal
@@ -1,5 +1,5 @@
 name:                vaultaire-collector-ceilometer
-version:             0.2.2
+version:             0.2.3
 synopsis:            Vaultaire Collector for Ceilometer
 homepage:            https://github.com/anchor/vaultaire-collector-ceilometer
 license:             BSD3


### PR DESCRIPTION
There were a couple of issues with this block of code.

#1 The impossible branch was not in fact impossible to reach (clearly). The reason here is that both f and mapToSourceDict can fail independently and would potentially require matching (Just x, Nothing) or (Nothing, Just y) in addition to (Just x, Just y). This was changed to match on "liftM2 (,) p sd" instead of (p, sd), which will be of type "Maybe (Word64, SourceDict)".

#2 The 'impossible' branch called error directly instead of errorM (logging function). This means that when this branch of code was hit the program immediately terminates instead of logging, bypassing the --continue-on-error implementation (which works through loggers, we should pretty much never be calling error directly for collectors).

Partially addresses #18 #19
