### PR TITLE
Added addresses tests + fixed address generation

### DIFF
--- a/lib/Vaultaire/Collector/Ceilometer/Process/Common.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/Common.hs
@@ -82,8 +82,8 @@ getIdElements :: Metric -> Text -> [Text]
 getIdElements m@Metric{..} name =
     let base     = [metricProjectId, metricResourceId, metricUOM, metricType, name]
         event    = case getEventType m of
-            Just eventType -> ["_event", eventType]
-            Nothing        -> []
+            Just _eventType -> ["_event"]
+            Nothing         -> []
         compound = ["_compound" | isCompound m]
     in concat [base,event,compound]
 

--- a/test/json_files/volumes/create_end.json
+++ b/test/json_files/volumes/create_end.json
@@ -1,0 +1,31 @@
+{
+    "id": "foo",
+    "name": "volume.size",
+    "project_id": "bar",
+    "resource_id": "baz",
+    "resource_metadata": {
+        "availability_zone": "syd1",
+        "created_at": "2015-03-10 05:26:40",
+        "display_name": "lala",
+        "event_type": "volume.create.end",
+        "host": "lulz",
+        "instance_uuid": null,
+        "launched_at": "2015-03-10 05:26:40.581771",
+        "replication_driver_data": null,
+        "replication_extended_status": null,
+        "replication_status": "disabled",
+        "size": 13,
+        "snapshot_id": null,
+        "status": "available",
+        "tenant_id": "fooz",
+        "user_id": "barz",
+        "volume_id": "bazez",
+        "volume_type": "foobar"
+    },
+    "source": "openstack",
+    "timestamp": "2015-03-10 05:26:40.623223",
+    "type": "gauge",
+    "unit": "GB",
+    "user_id": "barz",
+    "volume": 13
+}

--- a/test/json_files/volumes/create_start.json
+++ b/test/json_files/volumes/create_start.json
@@ -1,0 +1,31 @@
+{
+    "id": "foo",
+    "name": "volume.size",
+    "project_id": "bar",
+    "resource_id": "baz",
+    "resource_metadata": {
+        "availability_zone": "syd1",
+        "created_at": "2015-03-10 05:26:40",
+        "display_name": "lala",
+        "event_type": "volume.create.start",
+        "host": "lulz",
+        "instance_uuid": null,
+        "launched_at": "",
+        "replication_driver_data": null,
+        "replication_extended_status": null,
+        "replication_status": "disabled",
+        "size": 13,
+        "snapshot_id": null,
+        "status": "creating",
+        "tenant_id": "fooz",
+        "user_id": "barz",
+        "volume_id": "bazez",
+        "volume_type": "foobar"
+    },
+    "source": "openstack",
+    "timestamp": "2015-03-10 05:26:40.467595",
+    "type": "gauge",
+    "unit": "GB",
+    "user_id": "barz",
+    "volume": 13
+}

--- a/test/json_files/volumes/delete_end.json
+++ b/test/json_files/volumes/delete_end.json
@@ -1,0 +1,31 @@
+{
+    "id": "foo",
+    "name": "volume.size",
+    "project_id": "bar",
+    "resource_id": "baz",
+    "resource_metadata": {
+        "availability_zone": "syd1",
+        "created_at": "2015-03-10 05:26:40",
+        "display_name": "lala",
+        "event_type": "volume.delete.end",
+        "host": "lulz",
+        "instance_uuid": null,
+        "launched_at": "2015-03-10 05:26:40",
+        "replication_driver_data": null,
+        "replication_extended_status": null,
+        "replication_status": "disabled",
+        "size": 13,
+        "snapshot_id": null,
+        "status": "deleting",
+        "tenant_id": "fooz",
+        "user_id": "barz",
+        "volume_id": "bazez",
+        "volume_type": "foobar"
+    },
+    "source": "openstack",
+    "timestamp": "2015-03-10 05:27:01.149850",
+    "type": "gauge",
+    "unit": "GB",
+    "user_id": "barz",
+    "volume": 13
+}

--- a/test/json_files/volumes/delete_start.json
+++ b/test/json_files/volumes/delete_start.json
@@ -1,0 +1,31 @@
+{
+    "id": "foo",
+    "name": "volume.size",
+    "project_id": "bar",
+    "resource_id": "baz",
+    "resource_metadata": {
+        "availability_zone": "syd1",
+        "created_at": "2015-03-10 05:26:40",
+        "display_name": "lala",
+        "event_type": "volume.delete.start",
+        "host": "lulz",
+        "instance_uuid": null,
+        "launched_at": "2015-03-10 05:26:40",
+        "replication_driver_data": null,
+        "replication_extended_status": null,
+        "replication_status": "disabled",
+        "size": 13,
+        "snapshot_id": null,
+        "status": "deleting",
+        "tenant_id": "fooz",
+        "user_id": "barz",
+        "volume_id": "bazez",
+        "volume_type": "foobar"
+    },
+    "source": "openstack",
+    "timestamp": "2015-03-10 05:26:59.024217",
+    "type": "gauge",
+    "unit": "GB",
+    "user_id": "barz",
+    "volume": 13
+}

--- a/vaultaire-collector-ceilometer.cabal
+++ b/vaultaire-collector-ceilometer.cabal
@@ -1,5 +1,5 @@
 name:                vaultaire-collector-ceilometer
-version:             0.5.3
+version:             0.6.0
 synopsis:            Vaultaire Collectors for Openstack/Ceilometer
 description:         Provides two collectors for openstack/ceilometer.
                      vaultaire-collector-ceilometer collects metric data from


### PR DESCRIPTION
Address generation no longer uses the actual event type, but rather the presence of an event type. This is done such that all the different events (create, delete, etc.) will be stored in the same address.