### PR TITLE
Generalises IO to MonadIO  and exposes more functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: haskell
 env:
-  - 'UBUNTU_RELEASE=saucy GHCVER=7.8.3 CABALVER=1.20'
+  - 'UBUNTU_RELEASE=saucy GHCVER=7.8.4 CABALVER=1.20'
 
 before_install:
   - 'sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ ${UBUNTU_RELEASE} main universe"'

--- a/lib/Vaultaire/Collector/Ceilometer/Process/Common.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/Common.hs
@@ -3,8 +3,6 @@
 
 module Vaultaire.Collector.Ceilometer.Process.Common where
 
-import           Control.Applicative
-import           Control.Lens
 import           Control.Monad
 import           Control.Monad.Trans
 import           Crypto.MAC.SipHash                   (SipHash (..),
@@ -22,6 +20,7 @@ import           System.Log.Logger
 
 import           Ceilometer.Types
 import           Marquise.Client
+import qualified Vaultaire.Collector.Common.Types     as V (Collector)
 
 import           Vaultaire.Collector.Ceilometer.Types
 
@@ -100,7 +99,7 @@ siphash32 :: S.ByteString -> Word64
 siphash32 = (`shift` (-32)) . siphash
 
 -- | Processes a pollster with no special requirements
-processBasePollster :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processBasePollster :: MonadIO m => Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processBasePollster m@Metric{..} = do
     sd <- liftIO $ mapToSourceDict $ getSourceMap m
     case sd of
@@ -112,7 +111,7 @@ processBasePollster m@Metric{..} = do
         Nothing -> return []
 
 -- | Constructs the appropriate compound payload and vault data for an event
-processEvent :: (Metric -> IO (Maybe Word64)) -> Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processEvent :: MonadIO m => (Metric -> IO (Maybe Word64)) -> Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processEvent f m@Metric{..} = do
     p  <- liftIO $ f m
     sd <- liftIO $ mapToSourceDict $ getSourceMap m

--- a/lib/Vaultaire/Collector/Ceilometer/Process/IP.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/IP.hs
@@ -5,6 +5,7 @@ module Vaultaire.Collector.Ceilometer.Process.IP where
 
 import           Control.Applicative
 import           Control.Lens
+import           Control.Monad.Trans
 import           Data.Aeson
 import qualified Data.HashMap.Strict                           as H
 import           Data.Monoid
@@ -14,11 +15,12 @@ import           Data.Word
 import           System.Log.Logger
 
 import           Ceilometer.Types
+import qualified Vaultaire.Collector.Common.Types              as V (Collector)
 
 import           Vaultaire.Collector.Ceilometer.Process.Common
 import           Vaultaire.Collector.Ceilometer.Types
 
-processIpEvent :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processIpEvent :: MonadIO m => Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processIpEvent = processEvent getIpPayload
 
 parseIPStatus :: Maybe Value -> Maybe PFIPStatus

--- a/lib/Vaultaire/Collector/Ceilometer/Process/Image.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/Image.hs
@@ -5,6 +5,7 @@ module Vaultaire.Collector.Ceilometer.Process.Image where
 
 import           Control.Applicative
 import           Control.Lens
+import           Control.Monad.Trans
 import           Data.Aeson
 import qualified Data.HashMap.Strict                           as H
 import           Data.Monoid
@@ -14,11 +15,12 @@ import           Data.Word
 import           System.Log.Logger
 
 import           Ceilometer.Types
+import qualified Vaultaire.Collector.Common.Types              as V (Collector)
 
 import           Vaultaire.Collector.Ceilometer.Process.Common
 import           Vaultaire.Collector.Ceilometer.Types
 
-processImageSizeEvent :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processImageSizeEvent :: MonadIO m => Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processImageSizeEvent = processEvent getImagePayload
 
 parseImageStatus :: Text -> Maybe PFImageStatus

--- a/lib/Vaultaire/Collector/Ceilometer/Process/Instance.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/Instance.hs
@@ -18,17 +18,18 @@ import           Data.Word
 import           System.Log.Logger
 
 import           Ceilometer.Types                              hiding (Flavor)
+import qualified Vaultaire.Collector.Common.Types              as V (Collector)
 
 import           Vaultaire.Collector.Ceilometer.Process.Common
 import           Vaultaire.Collector.Ceilometer.Types
 
 
-processInstanceEvent :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processInstanceEvent :: MonadIO m =>  Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processInstanceEvent _ = return [] -- See https://github.com/anchor/vaultaire-collector-ceilometer/issues/4
 
 -- | Extracts vcpu, ram, disk and flavor data from an instance pollster
 --   Publishes each of these as their own metric with their own Address
-processInstancePollster :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processInstancePollster :: MonadIO m => Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processInstancePollster m@Metric{..} = do
     let baseMap = getSourceMap m --The sourcedict for the 4 metrics is mostly shared
     let names = ["instance_vcpus", "instance_ram", "instance_disk", "instance_flavor"]

--- a/lib/Vaultaire/Collector/Ceilometer/Process/Snapshot.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/Snapshot.hs
@@ -5,6 +5,7 @@ module Vaultaire.Collector.Ceilometer.Process.Snapshot where
 
 import           Control.Applicative
 import           Control.Lens
+import           Control.Monad.Trans
 import           Data.Aeson
 import qualified Data.HashMap.Strict                           as H
 import           Data.Monoid
@@ -14,11 +15,12 @@ import           Data.Word
 import           System.Log.Logger
 
 import           Ceilometer.Types
+import qualified Vaultaire.Collector.Common.Types              as V (Collector)
 
 import           Vaultaire.Collector.Ceilometer.Process.Common
 import           Vaultaire.Collector.Ceilometer.Types
 
-processSnapshotSizeEvent :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processSnapshotSizeEvent :: MonadIO m => Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processSnapshotSizeEvent = processEvent getSnapshotSizePayload
 
 parseSnapshotStatus :: Text -> Maybe PFSnapshotStatus

--- a/lib/Vaultaire/Collector/Ceilometer/Process/Volume.hs
+++ b/lib/Vaultaire/Collector/Ceilometer/Process/Volume.hs
@@ -5,6 +5,7 @@ module Vaultaire.Collector.Ceilometer.Process.Volume where
 
 import           Control.Applicative
 import           Control.Lens
+import           Control.Monad.Trans
 import           Data.Aeson
 import qualified Data.HashMap.Strict                           as H
 import           Data.Monoid
@@ -14,11 +15,12 @@ import           Data.Word
 import           System.Log.Logger
 
 import           Ceilometer.Types
+import qualified Vaultaire.Collector.Common.Types              as V (Collector)
 
 import           Vaultaire.Collector.Ceilometer.Process.Common
 import           Vaultaire.Collector.Ceilometer.Types
 
-processVolumeEvent :: Metric -> Collector [(Address, SourceDict, TimeStamp, Word64)]
+processVolumeEvent :: MonadIO m => Metric -> V.Collector o s m [(Address, SourceDict, TimeStamp, Word64)]
 processVolumeEvent = processEvent getVolumePayload
 
 parseVolumeStatus :: Text -> Maybe PFVolumeStatus

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -380,7 +380,7 @@ testMetricIntegration = do
         (Nothing, Nothing) -> assertFailure "Both client and server timed out"
         (Nothing, Just _ ) -> assertFailure "Client timed out"
         (Just _ , Nothing) -> assertFailure "Server timed out"
-        (Just _ , Just _ ) -> return ()   
+        (Just _ , Just _ ) -> return ()
 
 testAddresses :: IO ()
 testAddresses = runNullCollector $ do

--- a/vaultaire-collector-ceilometer.cabal
+++ b/vaultaire-collector-ceilometer.cabal
@@ -1,5 +1,5 @@
 name:                vaultaire-collector-ceilometer
-version:             0.7.0
+version:             0.7.1
 synopsis:            Vaultaire Collectors for Openstack/Ceilometer
 description:         Provides two collectors for openstack/ceilometer.
                      vaultaire-collector-ceilometer collects metric data from

--- a/vaultaire-collector-ceilometer.cabal
+++ b/vaultaire-collector-ceilometer.cabal
@@ -59,6 +59,7 @@ library
                      -Wall
                      -Wwarn
                      -fwarn-tabs
+                     -fno-spec-constr
 
   ghc-prof-options:  -fprof-auto
 


### PR DESCRIPTION
Exposes the process functions, which allows one to convert a fully constructed Metric into tuples suitable for collection.

Also generalises the options and state types for functions which do not require them to be fixed to CeilometerOptions and CeilometerState respectively.